### PR TITLE
tests: add test to check behaviour with bad command

### DIFF
--- a/.github/workflows/vader-vim.yaml
+++ b/.github/workflows/vader-vim.yaml
@@ -68,6 +68,11 @@ jobs:
           vim -Es -Nu init.vim -c 'silent Vader! test/bad_server_command/*.vader'
         timeout-minutes: 2
 
+      - name: Test Vim (with c-worksheetify-server not on PATH)
+        run: |
+          vim -Es -Nu init.vim -c 'silent Vader! test/command_not_found/*.vader'
+        timeout-minutes: 2
+
       - name: Test NeoVim
         run: |
           # Uploaded release compiled with recent Java.
@@ -82,6 +87,12 @@ jobs:
           while pgrep --full 'edu.nus.worksheet.WorksheetifyServer' > /dev/null; do
               sleep 0.5
           done
+
+      - name: Test NeoVim (with bad c-worksheetify-server)
+        run: |
+          export PATH=test/bad_server_command:$PATH
+          nvim -Es -u init.vim -c 'silent Vader! test/bad_server_command/*.vader'
+        timeout-minutes: 2
 
       - name: Test NeoVim (with bad c-worksheetify-server)
         run: |

--- a/.github/workflows/vader-vim.yaml
+++ b/.github/workflows/vader-vim.yaml
@@ -25,6 +25,15 @@ jobs:
           wget https://github.com/rgoulter/c-worksheet-instrumentor/releases/download/v0.2.6/c-worksheet-instrumentor-0.2.6.tar
           tar -xf c-worksheet-instrumentor-0.2.6.tar
 
+      - name: Setup Vim Config init.vim
+        run: |
+          echo <(cat << VIMRC > init.vim
+          set rtp+=vader.vim
+          set rtp+=.
+          filetype plugin indent on
+          VIMRC
+          )
+
       - name: Demonstrate C Worksheet
         run: |
           # Uploaded release compiled with recent Java.
@@ -43,12 +52,7 @@ jobs:
           # Uploaded release compiled with recent Java.
           export JAVA_HOME=$JAVA_HOME_21_X64
           export PATH=c-worksheet-instrumentor-0.2.6/bin:$PATH
-          vim -Es -Nu <(cat << VIMRC
-          set rtp+=vader.vim
-          set rtp+=.
-          filetype plugin indent on
-          VIMRC
-          ) -c 'silent Vader! test/*'
+          vim -Es -Nu init.vim -c 'silent Vader! test/*.vader'
         timeout-minutes: 2
 
       - name: Test NeoVim
@@ -56,10 +60,5 @@ jobs:
           # Uploaded release compiled with recent Java.
           export JAVA_HOME=$JAVA_HOME_21_X64
           export PATH=c-worksheet-instrumentor-0.2.6/bin:$PATH
-          nvim -Es -u <(cat << VIMRC
-          set rtp+=vader.vim
-          set rtp+=.
-          filetype plugin indent on
-          VIMRC
-          ) -c 'silent Vader! test/*'
+          nvim -Es -u init.vim -c 'silent Vader! test/*.vader'
         timeout-minutes: 2

--- a/.github/workflows/vader-vim.yaml
+++ b/.github/workflows/vader-vim.yaml
@@ -55,10 +55,32 @@ jobs:
           vim -Es -Nu init.vim -c 'silent Vader! test/*.vader'
         timeout-minutes: 2
 
+      - name: Test Vim (with bad c-worksheetify-server)
+        run: |
+          # Kill server (if running)
+          pkill --full 'edu.nus.worksheet.WorksheetifyServer' || true
+
+          export PATH=test/bad_server_command:$PATH
+          vim -Es -Nu init.vim -c 'silent Vader! test/bad_server_command/*.vader'
+        timeout-minutes: 2
+
       - name: Test NeoVim
         run: |
           # Uploaded release compiled with recent Java.
           export JAVA_HOME=$JAVA_HOME_21_X64
           export PATH=c-worksheet-instrumentor-0.2.6/bin:$PATH
           nvim -Es -u init.vim -c 'silent Vader! test/*.vader'
+        timeout-minutes: 2
+
+      - name: Kill Server
+        run: |
+          pkill --signal SIGTERM --full 'edu.nus.worksheet.WorksheetifyServer' || true
+          while pgrep --full 'edu.nus.worksheet.WorksheetifyServer' > /dev/null; do
+              sleep 0.5
+          done
+
+      - name: Test NeoVim (with bad c-worksheetify-server)
+        run: |
+          export PATH=test/bad_server_command:$PATH
+          nvim -Es -u init.vim -c 'silent Vader! test/bad_server_command/*.vader'
         timeout-minutes: 2

--- a/.github/workflows/vader-vim.yaml
+++ b/.github/workflows/vader-vim.yaml
@@ -55,11 +55,15 @@ jobs:
           vim -Es -Nu init.vim -c 'silent Vader! test/*.vader'
         timeout-minutes: 2
 
+      - name: Kill Server
+        run: |
+          pkill --signal SIGTERM --full 'edu.nus.worksheet.WorksheetifyServer' || true
+          while pgrep --full 'edu.nus.worksheet.WorksheetifyServer' > /dev/null; do
+              sleep 0.5
+          done
+
       - name: Test Vim (with bad c-worksheetify-server)
         run: |
-          # Kill server (if running)
-          pkill --full 'edu.nus.worksheet.WorksheetifyServer' || true
-
           export PATH=test/bad_server_command:$PATH
           vim -Es -Nu init.vim -c 'silent Vader! test/bad_server_command/*.vader'
         timeout-minutes: 2

--- a/autoload/cworksheet.vim
+++ b/autoload/cworksheet.vim
@@ -68,8 +68,16 @@ import vim
 #  properly running, just trying to run it (and ignoring if it crashes
 #  because the port is already is in use) should work.
 wsfy_cmd = vim.eval("l:cmd")
-start_server(wsfy_cmd)
+wsfy_start_server_success = start_server(wsfy_cmd)
+EOF
 
+    if !py3eval("wsfy_start_server_success")
+      echoerr "unable to start c-worksheetify server!"
+      return
+    endif
+
+    python3 << EOF
+import vim
 
 wsfy_port = int(vim.eval("g:cworksheetify_server_port"))
 c_src_filename = vim.eval("l:cSrcFilename")

--- a/autoload/cworksheet.vim
+++ b/autoload/cworksheet.vim
@@ -80,35 +80,41 @@ c_src = "\n".join(vim.current.buffer[:])
 # wsfy_results = run_worksheetify_client("localhost", wsfy_port, c_src_filename)
 wsfy_results = run_worksheetify_client_with_text("localhost", wsfy_port, c_src)
 
-
-# `wsfy_results` is list of raw strings;
-# `wsfy_output` assumed to be **spaces + comments + result**.
-col_for_ws = 50
-wsfy_output = with_spaces_and_comments(vim.current.buffer[:], wsfy_results, col_for_ws)
+wsfy_output = None
+wsfy_success = False
+if wsfy_results:
+    # `wsfy_results` is list of raw strings;
+    # `wsfy_output` assumed to be **spaces + comments + result**.
+    col_for_ws = 50
+    wsfy_output = with_spaces_and_comments(vim.current.buffer[:], wsfy_results, col_for_ws)
+    wsfy_success = True
 
 EOF
 
     " Assumes vim has python3 support
     let ws_output = py3eval("wsfy_output")
+    let wsfy_success = py3eval("wsfy_success")
 
-    " Each enter in `ws_output` corresponds to output to
-    "  append-to the line.
-    " Being from line 1.
-    let currLine = 1
-    for output in ws_output
-        " Append to cursor position
-        call append(currLine, output)
+    if wsfy_success
+        " Each enter in `ws_output` corresponds to output to
+        "  append-to the line.
+        " Being from line 1.
+        let currLine = 1
+        for output in ws_output
+            " Append to cursor position
+            call append(currLine, output)
 
-        " Worksheetify assumes that the first string of result is
-        " appended to the *same* line. So, we join the currentLine with the
-        " next.
-        if len(output) > 0
-            execute (currLine) . "j!"
-        endif
+            " Worksheetify assumes that the first string of result is
+            " appended to the *same* line. So, we join the currentLine with the
+            " next.
+            if len(output) > 0
+                execute (currLine) . "j!"
+            endif
 
-        " The next line to append to. Increase by at least 1.
-        let currLine = currLine + max([1, len(output)])
-    endfor
+            " The next line to append to. Increase by at least 1.
+            let currLine = currLine + max([1, len(output)])
+        endfor
+    endif
 
     call s:restoreview()
 endfunction

--- a/python/cworksheet/worksheetclient.py
+++ b/python/cworksheet/worksheetclient.py
@@ -39,7 +39,10 @@ def is_port_in_use(port):
 # as a result corresponding to each line of the input file.
 def run_worksheetify_client_req(hostname, port, message):
 	clientsocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	clientsocket.connect((hostname, port))
+	try:
+		clientsocket.connect((hostname, port))
+	except:
+		return None
 
 	clientsocket.sendall(message.encode('utf-8'))
 	clientsocket.shutdown(socket.SHUT_WR)

--- a/python/cworksheet/worksheetclient.py
+++ b/python/cworksheet/worksheetclient.py
@@ -13,13 +13,20 @@ def start_server(cmdStr):
 	is_posix = not sys.platform.startswith("win")
 	cmd = shlex.split(cmdStr, posix = is_posix)
 
-	srv_p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+	try:
+		srv_p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+	except:
+		return False
 
 	# From v0.2.2, Server should output at least one line when it runs,
 	# So we can 'block' until it runs.
+	#
 	# If server already running (when we try to run another one), it will
 	#  write errors to the same file.
+	# (and we silently ignore it).
 	srv_p.stdout.readline()
+
+	return True
 
 
 

--- a/test/bad_server_command/bad-command.vader
+++ b/test/bad_server_command/bad-command.vader
@@ -1,0 +1,36 @@
+# I observed CI got stuck when the c-worksheetify-server command
+# didn't run. (e.g. the Java version was too old).
+#
+# i.e. the `c-worksheetify-server` is on PATH, but fails to run a server.
+#
+# Let's cover this scenario by using a bad cworksheetify server command.
+
+
+Before (set c-worksheetify-server to a command which won't work):
+  let old_cworksheetify_server_command = "c-worksheetify-server"
+  if exists("g:cworksheetify_server_command")
+    let old_cworksheetify_server_command = g:cworksheetify_server_command
+    g:cworksheetify_server_command = "false"
+  else
+    let g:cworksheetify_server_command = "false"
+  endif
+
+Given c (a hello world C program):
+  #include <stdio.h>
+
+  int main(int argc, char **argv) {
+    printf("Hello World\n");
+  }
+
+Do (:CWorksheetEvaluate, which should do nothing):
+  :CWorksheetEvaluate\<CR>
+
+Expect c (the same hello world C program):
+  #include <stdio.h>
+
+  int main(int argc, char **argv) {
+    printf("Hello World\n");
+  }
+
+After (restore c-worksheetify-server to default command):
+  let g:cworksheetify_server_command = old_cworksheetify_server_command

--- a/test/bad_server_command/c-worksheetify-server
+++ b/test/bad_server_command/c-worksheetify-server
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exit 1

--- a/test/command_not_found/bad-command.vader
+++ b/test/command_not_found/bad-command.vader
@@ -1,0 +1,39 @@
+# I observed CI got stuck when the c-worksheetify-server command
+# didn't run. (e.g. the Java version was too old).
+#
+# i.e. the `c-worksheetify-server` is on PATH, but fails to run a server.
+#
+# Let's cover this scenario by using a bad cworksheetify server command.
+
+
+Before (set c-worksheetify-server to a command which won't work):
+  let old_cworksheetify_server_command = "c-worksheetify-server"
+  if exists("g:cworksheetify_server_command")
+    let old_cworksheetify_server_command = g:cworksheetify_server_command
+    g:cworksheetify_server_command = "false"
+  else
+    let g:cworksheetify_server_command = "false"
+  endif
+
+Given c (a hello world C program):
+  #include <stdio.h>
+
+  int main(int argc, char **argv) {
+    printf("Hello World\n");
+  }
+
+Do (:CWorksheetEvaluate, which should do nothing):
+  :AssertThrows CWorksheetEvaluate\<CR>
+
+Then (check that CWorksheetEvaluate threw the expected exception):
+  AssertEqual g:vader_exception, "Vim(echoerr):unable to start c-worksheetify server!"
+
+Expect c (the same hello world C program):
+  #include <stdio.h>
+
+  int main(int argc, char **argv) {
+    printf("Hello World\n");
+  }
+
+After (restore c-worksheetify-server to default command):
+  let g:cworksheetify_server_command = old_cworksheetify_server_command


### PR DESCRIPTION
When adding the CI tests, since the `java` version was older than what had been used to build the `c-worksheet-instrumentor` release, the tests got stuck.

Add a test case to check that the `:CWorksheetEvaluate` can suitably handle a bad command.